### PR TITLE
Changed xlmhg to xlmhglite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ seaborn~=0.11.2
 adjustText~=0.7.3
 networkx~=2.7
 jupyter~=1.0.0
-xlmhg~=2.5.4
+xlmhglite~=1.1.0
 statsmodels~=0.13.1

--- a/src/mebocost/pathway_enrichment.py
+++ b/src/mebocost/pathway_enrichment.py
@@ -13,7 +13,7 @@ import collections
 import pickle as pk
 import traceback
 from datetime import datetime
-import xlmhg
+import xlmhglite
 from scipy import sparse
 
 import multiprocessing
@@ -168,7 +168,7 @@ class PathwayEnrich:
     def getmHG(self, genes_indices, N, X, L):
         # genes_indices = sorted(set(genes_indices))
         go_indices = np.uint16(genes_indices)
-        res = xlmhg.get_xlmhg_test_result(N, go_indices, X=X, L=L)
+        res = xlmhglite.get_xlmhg_test_result(N, go_indices, X=X, L=L)
         try:
             res_list = ["%s,%s,%s,%s"%(res.N, res.cutoff, res.K, res.k), res.stat, res.fold_enrichment, res.pval]
         except:

--- a/src/mebocost/pathway_plot.py
+++ b/src/mebocost/pathway_plot.py
@@ -14,7 +14,7 @@ import pandas as pd
 import traceback
 import matplotlib
 import collections
-import xlmhg
+import xlmhglite
 import seaborn as sns
 from adjustText import adjust_text
 from matplotlib import pyplot as plt


### PR DESCRIPTION
As mentioned in https://github.com/flo-compbio/xlmhg/issues/7#issuecomment-1586104913 I have updated Mebocost to use xlmhglite instead of xlmhg, to support newer versions of Python.